### PR TITLE
Update README.md: circular avatars *are* bad

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Installation is extremely easy: just go to [the Chrome extension store](https://
 
 4. **Add row separators in file explorer:** The file explorer that shows all the files and folders currently has no borders between rows, making it harder to read the file list.
 
-5. **Remove circular user images:** This one isn't necessarily a bad change, but just to keep with the classic GitHub UI, I reverted the new circular user images to the old square (but with rounded corners) images.
+5. **Remove circular user images:**
+   The new `border-radius: 50% !important` setting
+   results in unwanted rounding near the corners,
+   cropping significant features from avatars which are intended to be square.
 
 And many other UI fixes such as fix the text width of issue counters and issue label, fix the whitespace of issues, add a slight background to README title, and more.
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ Installation is extremely easy: just go to [the Chrome extension store](https://
 
 4. **Add row separators in file explorer:** The file explorer that shows all the files and folders currently has no borders between rows, making it harder to read the file list.
 
-5. **Remove circular user images:**
-   The new `border-radius: 50% !important` setting
-   results in unwanted rounding near the corners,
-   cropping significant features from avatars which are intended to be square.
+5. **Remove circular user images:** The new `border-radius: 50% !important` setting results in unwanted rounding near the corners, cropping significant features from avatars which are intended to be square.
 
 And many other UI fixes such as fix the text width of issue counters and issue label, fix the whitespace of issues, add a slight background to README title, and more.
 


### PR DESCRIPTION
Replace "isn't necessarily a bad change" with reason why circular cropping is bad.

Cropping is bad for users whose avatars are meant to be square.

E.g. [me], [WhiteyDude], [gregkh], [ry], [gdabu], [DynamicDream], [maehr], [gepcel], anyone using an identicon with pixels in the corners, ...

![bad](https://user-images.githubusercontent.com/48375680/85594563-9dec5d00-b67a-11ea-9f9c-1cc1b9ee1b3a.png)

[me]: https://github.com/yawnoc
[WhiteyDude]: https://github.com/WhiteyDude
[gregkh]: https://github.com/gregkh
[ry]: https://github.com/ry
[gdabu]: https://github.com/gdabu
[DynamicDream]: https://github.com/DynamicDream
[maehr]: https://github.com/maehr
[gepcel]: https://github.com/gepcel

