### PR TITLE
Tweak Borders and Header Tabs

### DIFF
--- a/css/osgh.css
+++ b/css/osgh.css
@@ -34,8 +34,8 @@
 }
 
 /* Add the row separators in the list of files on a repo's main page */
-.js-active-navigation-container .Box-row.border-top-0 {
-  border-top: 1px solid #e1e4e8 !important;
+.js-active-navigation-container .Box-row.border-top-0 + .Box-row.border-top-0 {
+  border-top: 1px solid #eaecef !important;
 }
 
 /* Slightly more compact file list rows and box headers */
@@ -53,10 +53,15 @@ body .avatar-user {
   border-radius: 6px !important;
 }
 
+/* Box border was slightly darker in classic design */
+.Box {
+  border-color: #d1d5da !important;
+}
+
 /* README should have a slight background */
 #readme .Box-header {
   background: #f6f8fa !important;
-  border-bottom: 1px solid #d1d5da !important;
+  border: 1px solid #d1d5da !important;
 }
 
 /* Issue counters and labels are too thin */

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -1,5 +1,8 @@
 /* Move headers to the middle */
 @media (min-width: 1280px) {
+  main > .pagehead {
+    box-shadow: inset 0 -1px 0 #e1e4e8;
+  }
   main > .pagehead > div,
   main > .pagehead > nav {
     max-width: 1280px;

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -25,7 +25,12 @@
   border-right: 1px solid #e1e4e8;
   border-bottom: none;
   border-top: 3px solid #e36209;
-  padding-top: 3px;
+  padding-top: 0;
+}
+
+/* Slightly more compact header tabs */
+.UnderlineNav-body .UnderlineNav-item {
+  padding: 5px 14px 3px;
 }
 
 /* Add the row separators in the list of files on a repo's main page */

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -17,6 +17,11 @@
   }
 }
 
+/* Slightly more compact header tabs */
+.UnderlineNav-body .UnderlineNav-item {
+  padding: 5px 14px 3px;
+}
+
 /* Highlight the selected page in the header */
 .UnderlineNav-item.selected {
   border-radius: 3px 3px 0 0;
@@ -26,11 +31,6 @@
   border-bottom: none;
   border-top: 3px solid #e36209;
   padding-top: 0;
-}
-
-/* Slightly more compact header tabs */
-.UnderlineNav-body .UnderlineNav-item {
-  padding: 5px 14px 3px;
 }
 
 /* Add the row separators in the list of files on a repo's main page */


### PR DESCRIPTION
This PR tweaks a few things to get a bit closer to the classic github UI.  I used this page from the wayback machine as a reference:
https://web.archive.org/web/20200604200137/github.com/django/django

- Makes the header underline full width on wider screens
- Makes the header tabs slightly more compact to better match the classic style
- Squishes the border below the blue file list header down to 1 pixel
- Slightly darkens the box border color to match the classic style

![Annotation 2020-06-24 230941](https://user-images.githubusercontent.com/281482/85649279-b8213d80-b670-11ea-88f0-b7bac86515ec.png)
