### PR TITLE
Apply CSS site wide, fix profile page issues, and fix visible re-paints in Firefox

### DIFF
--- a/css/osgh.css
+++ b/css/osgh.css
@@ -17,13 +17,13 @@
   }
 }
 
-/* Slightly more compact header tabs */
-.UnderlineNav-body .UnderlineNav-item {
+/* Slightly more compact header tabs (excluding sticky header on user profile page) */
+body:not(.page-profile) .UnderlineNav-body .UnderlineNav-item {
   padding: 5px 14px 3px;
 }
 
-/* Highlight the selected page in the header */
-.UnderlineNav-item.selected {
+/* Highlight the selected page in the header (excluding sticky header on user profile page) */
+body:not(.page-profile) .UnderlineNav-item.selected {
   border-radius: 3px 3px 0 0;
   background: #fff;
   border-left: 1px solid #e1e4e8;

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -185,3 +185,29 @@ body .btn-outline[disabled] {
   border-color: rgba(27,31,35,.15);
   box-shadow: 0 1px 0 rgba(27,31,35,.04), inset 0 1px 0 hsla(0,0%,100%,.25);
 }
+
+/* User profile page: move status badge back below avatar image */
+.user-status-container .user-status-circle-badge-container {
+  position: unset;
+  width: auto;
+  height: auto;
+  margin: 4px 0 0;
+}
+.user-status-circle-badge-container .user-status-circle-badge {
+  border-radius: 6px;
+  width: 100%;
+}
+body .user-status-circle-badge .user-status-message-wrapper {
+  width: 100%;
+  opacity: 1;
+}
+body .user-status-circle-badge-container .user-status-emoji-container {
+  margin-right: 8px !important;
+}
+body .user-status-circle-badge-container .user-status-circle-badge,
+body .user-status-circle-badge-container:hover .user-status-circle-badge {
+  box-shadow: none; 
+}
+.user-status-message-wrapper .css-truncate.css-truncate-target {
+  white-space: auto;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
       "matches": [
         "https://github.com/*"
       ],
-	  "css": ["css/osgh.css"]
+      "css": ["css/osgh.css"],
+      "run_at": "document_start"
     }
   ],
   "homepage_url": "https://github.com/daattali/oldschool-github-extension"

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "content_scripts": [
     {
       "matches": [
-        "https://github.com/*/*"
+        "https://github.com/*"
       ],
 	  "css": ["css/osgh.css"]
     }


### PR DESCRIPTION
This PR does the following:

**Injects the css on all github urls** 
So issues can be fixed on the user page, organization page, home page, notifications page, etc.

**Excludes the user profile header tabs from classic tab styling rules**
Turns out this page has a sticky header (unlike any other page) and the classic style tabs do not look good with it.

**Moves status badge back below the user avatar on the profile page**
With the osgh.css applied to the profile page, the avatar changed from a circle to a square.  This made the little round status badge sit fully on top of the image instead of right on the edge as it did with the circle.  This did not look good, so I moved it down below the avatar, expanded it so the text is always visible (no reveal on hover), and made it a rectangle.  This is not exactly how it looked before the 6/23 UI changes, but it's pretty close.

Closes #8

**Injects css earlier to prevent re-paints after page load in Firefox**
Firefox was injecting the css after page load causing a visible flash as the restyled elements changed.  Didn't seem to be a problem in Chrome.  Adding `"run_at": "document_start"` to the manifest fixes the issue in Firefox and doesn't seem to cause an issue in Chrome.  [More info on this here](https://discourse.mozilla.org/t/modify-a-web-page-before-displaying-it-webextensions/16002).





