### PR TITLE
Apply CSS To gist.github.com As Well

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://github.com/*"
+        "https://github.com/*",
+        "https://gist.gihub.com/*"
       ],
       "css": ["css/osgh.css"],
       "run_at": "document_start"


### PR DESCRIPTION
The unwanted new ui has spread!  The interface on gist.github.com is very similar so the css overrides in this extension work well there too.