### PR TITLE
Fix gihub misspelling in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     {
       "matches": [
         "https://github.com/*",
-        "https://gist.gihub.com/*"
+        "https://gist.github.com/*"
       ],
       "css": ["css/osgh.css"],
       "run_at": "document_start"


### PR DESCRIPTION
So turns out I left the **t** out of gi**t**hub when separating the gist.github.com addition out as it's own PR 😳.  So the official v1.3 doesn't actually work on gist.github.com.  Sorry about that!