### PR TITLE
a few button, border, and icon color refinements

### DIFF
--- a/css/osgh.css
+++ b/css/osgh.css
@@ -154,7 +154,7 @@ body .btn:hover {
   border-color: rgba(27,31,35,0.35);
 }
 body [open] > .btn, body [open] > summary > .btn, body .btn:active {
-  background-color: #e9ecef;
+  background: #e9ecef;
   border-color: rgba(27,31,35,0.35);
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
 }

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -153,7 +153,7 @@ body .btn:hover {
   background-image: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
   border-color: rgba(27,31,35,0.35);
 }
-body [open]>.btn, body .btn:active {
+body [open] .btn, body .btn:active {
   background-color: #e9ecef;
   border-color: rgba(27,31,35,0.35);
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -153,7 +153,13 @@ body .btn:hover {
   background-image: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
   border-color: rgba(27,31,35,0.35);
 }
-body [open] > .btn, body [open] > summary > .btn, body .btn:active {
+/* 
+  The github stylesheet contains this rule:  body.intent-mouse a:focus { box-shadow: none }
+  It wins over this selector and removes the inset shadow:  body .btn:active  
+  So we need to override it with:  html > body.intent-mouse .btn:active
+  Could also be done by adding !important to box-shadow.
+*/
+body [open] > .btn, body [open] > summary > .btn, body .btn:active, html > body.intent-mouse .btn:active {
   background: #e9ecef;
   border-color: rgba(27,31,35,0.35);
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -153,7 +153,7 @@ body .btn:hover {
   background-image: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
   border-color: rgba(27,31,35,0.35);
 }
-body [open] .btn, body .btn:active {
+body [open] > .btn, body [open] > summary > .btn, body .btn:active {
   background-color: #e9ecef;
   border-color: rgba(27,31,35,0.35);
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -106,7 +106,12 @@ body .avatar-user {
 }
 
 /* Box border was slightly darker in classic design */
-body .Box {
+body .Box, body .Box-header {
+  border-color: #d1d5da;
+}
+
+/* Form field borders were slightly darker in classic design */
+body .form-control {
   border-color: #d1d5da;
 }
 
@@ -135,16 +140,21 @@ body .IssueLabel--big.lh-condensed,
 body .btn {
   transition: none !important;
   font-weight: 600;
-  background: linear-gradient(-180deg, #fafbfc 0%, #eff3f6 90%);
+  background-image: linear-gradient(-180deg, #fafbfc 0%, #eff3f6 90%);
   /* Set only border color here (not width) to avoid adding extra borders that shouldn't exists */
-  border-color: rgba(27,31,35,0.2);  
+  border-color: rgba(27,31,35,0.2);
+  /* these three background properties help the border color blend in better with the button color*/
+  background-repeat: repeat-x;
+  background-position: -1px -1px;
+  background-size: 110% 110%;
+  box-shadow: none;
 }
 body .btn:hover {
-  background: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
+  background-image: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
   border-color: rgba(27,31,35,0.35);
 }
 body [open]>.btn, body .btn:active {
-  background: #e9ecef;
+  background-color: #e9ecef;
   border-color: rgba(27,31,35,0.35);
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
 }
@@ -155,12 +165,28 @@ body .btn[disabled] {
   border-color: rgba(27,31,35,.15);
 }
 
+/* Revert button icon colors/opacity */
+body .btn .octicon {
+  color: #24292e;
+}
+body .btn .dropdown-caret {
+  opacity: 1;
+}
+body .btn-primary .octicon {
+  color: #fff;
+}
+
+/* Match social count boxes to button styles */
+body .social-count {
+  border-color: rgba(27,31,35,0.2);
+  box-shadow: none;
+}
 
 body .btn-primary {
-  background: linear-gradient(-180deg, #34d058 0%, #28a745 90%);
+  background-image: linear-gradient(-180deg, #34d058 0%, #28a745 90%);
 }
 body .btn-primary:hover {
-  background: linear-gradient(-180deg, #2fcb53 0%, #269f42 90%);
+  background-image: linear-gradient(-180deg, #2fcb53 0%, #269f42 90%);
   border-color: rgba(27,31,35,0.5);
 }
 body [open]>.btn-primary, body .btn-primary:active {

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -161,10 +161,10 @@ body [open] > .btn, body [open] > summary > .btn, body .btn:active {
 }
 /* 
   The github stylesheet contains this rule:  body.intent-mouse a:focus { box-shadow: none }
-  It overrides the rule above and removes the inset shadow. This extra has higher specificity
+  It overrides the rule above and removes the inset shadow. This extra rule has higher specificity
   to beat it and put the shadow back.  Adding !important to box-shadow above could also do the trick.
 */
-html > body.intent-mouse .btn:active {
+html > body.intent-mouse [open] > .btn, html > body.intent-mouse .btn:active {
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
 }
 body .btn[disabled] {

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -53,10 +53,10 @@ body:not(.page-profile) .UnderlineNav-item.selected {
 }
 
 /* Content boxes border radius revert */
-.repository-content .Box {
+body .Box {
   border-radius: 3px;
 }
-.repository-content .Box .Box-header, body .Box-row:first-of-type {
+body .Box .Box-header, body .Box-row:first-of-type {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
 }
@@ -108,6 +108,10 @@ body .avatar-user {
 /* Box border was slightly darker in classic design */
 body .Box:not(.Box--danger), body .Box-header {
   border-color: #d1d5da;
+}
+/* Hide duplicated red top border of danger boxes - probably a github oversight */
+body .Box--danger .Box-row:first-of-type {
+  border-top-color: transparent;
 }
 
 /* Form field borders were slightly darker in classic design */

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -153,15 +153,18 @@ body .btn:hover {
   background-image: linear-gradient(-180deg, #f0f3f6 0%, #e6ebf1 90%);
   border-color: rgba(27,31,35,0.35);
 }
-/* 
-  The github stylesheet contains this rule:  body.intent-mouse a:focus { box-shadow: none }
-  It wins over this selector and removes the inset shadow:  body .btn:active  
-  So we need to override it with:  html > body.intent-mouse .btn:active
-  Could also be done by adding !important to box-shadow.
-*/
-body [open] > .btn, body [open] > summary > .btn, body .btn:active, html > body.intent-mouse .btn:active {
+
+body [open] > .btn, body [open] > summary > .btn, body .btn:active {
   background: #e9ecef;
   border-color: rgba(27,31,35,0.35);
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+}
+/* 
+  The github stylesheet contains this rule:  body.intent-mouse a:focus { box-shadow: none }
+  It overrides the rule above and removes the inset shadow. This extra has higher specificity
+  to beat it and put the shadow back.  Adding !important to box-shadow above could also do the trick.
+*/
+html > body.intent-mouse .btn:active {
   box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
 }
 body .btn[disabled] {

--- a/css/osgh.css
+++ b/css/osgh.css
@@ -56,7 +56,7 @@ body:not(.page-profile) .UnderlineNav-item.selected {
 .repository-content .Box {
   border-radius: 3px;
 }
-.repository-content .Box .Box-header {
+.repository-content .Box .Box-header, body .Box-row:first-of-type {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
 }
@@ -106,7 +106,7 @@ body .avatar-user {
 }
 
 /* Box border was slightly darker in classic design */
-body .Box, body .Box-header {
+body .Box:not(.Box--danger), body .Box-header {
   border-color: #d1d5da;
 }
 


### PR DESCRIPTION
A something still wasn't looking quite right about some of the contrast and line weights so I looked closely and the old css through the wayback machine and made some more refinements to match the classic style even more closely.

- Slightly darker icons on watch, star, and fork buttons at the top of page
- Slightly darker border on counter boxes next to them
- Slightly darker borders on form text fields
- Slightly darker borders on Box-headers (match the rest of the Box)
- Remove subtle box-shadow from buttons that didn't exist in classic style
- Better blending of button border and background

All the css rules are taken straight from a recent wayback machine copy of github.  These changes are very subtle, but I feel they bring back just a little more contrast and polish to the overall look.

**Before**
<img width="1078" alt="Screen Shot 2020-07-01 at 12 17 41 AM" src="https://user-images.githubusercontent.com/281482/86203334-c076ee00-bb32-11ea-9bdc-f0a255fcac18.png">

**After**
<img width="1079" alt="Screen Shot 2020-07-01 at 12 15 59 AM" src="https://user-images.githubusercontent.com/281482/86203339-c40a7500-bb32-11ea-9ea5-250a3e52b2e2.png">
